### PR TITLE
Add role checks to admin pages

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -2,6 +2,10 @@
   define('REQUIRE_SESSION', true);
   $pageTitle = 'Zerspanungsrechner';
   include 'header.php';
+require 'session_check.php';
+if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
+  die('Zugriff verweigert');
+}
 ?>
 <!DOCTYPE html>
 <html lang="de">

--- a/admin_user.php
+++ b/admin_user.php
@@ -2,6 +2,10 @@
   define('REQUIRE_SESSION', true);
   $pageTitle = 'Zerspanungsrechner';
   include 'header.php';
+require 'session_check.php';
+if ($_SESSION['rolle'] !== 'admin') {
+  die('Zugriff verweigert');
+}
 ?>
 <!DOCTYPE html>
 <html lang="de">


### PR DESCRIPTION
## Summary
- restrict access to admin.php for only `admin` and `editor`
- restrict access to admin_user.php to `admin`

## Testing
- `php -l admin.php` *(fails: `php` not found)*
- `php -l admin_user.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402610c99883279713d426892d4803