### PR TITLE
Fix header comment in export_pdf

### DIFF
--- a/export_pdf.php
+++ b/export_pdf.php
@@ -52,7 +52,8 @@ if (file_exists($logoSvg) && method_exists($pdf, 'ImageSVG')) {
 // Abstand nach Logo
 $pdf->Ln(20);
 
-// Überschrift\ n$pdf->SetFont('helvetica', 'B', 16);
+// Überschrift
+$pdf->SetFont('helvetica', 'B', 16);
 $pdf->Cell(0, 0, 'Zerspanungs-Ergebnis', 0, 1, 'C');
 $pdf->Ln(5);
 


### PR DESCRIPTION
## Summary
- correct the `// Überschrift\ n` comment in `export_pdf.php`

## Testing
- `php -l export_pdf.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684026336ab88327b1616518ee332513