### PR TITLE
Fix delete endpoints

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -141,7 +141,10 @@
     }
 
     async function deleteMaterial(id) {
-      await fetch('delete_material.php?id=' + id);
+      await fetch('delete_material.php', {
+        method: 'POST',
+        body: new URLSearchParams({ id })
+      });
       loadData();
     }
 
@@ -179,7 +182,10 @@
     }
 
     async function deletePlatte(id) {
-      await fetch('delete_platte.php?id=' + id);
+      await fetch('delete_platte.php', {
+        method: 'POST',
+        body: new URLSearchParams({ id })
+      });
       loadData();
     }
 

--- a/delete_material.php
+++ b/delete_material.php
@@ -10,7 +10,7 @@ if (defined('DEMO_MODE') && DEMO_MODE) {
 $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-if (isset($_POST['id'])) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['id'])) {
   $stmt = $pdo->prepare("DELETE FROM materialien WHERE id = ?");
   $stmt->execute([$_POST['id']]);
   echo "OK";

--- a/delete_platte.php
+++ b/delete_platte.php
@@ -10,8 +10,8 @@ if (defined('DEMO_MODE') && DEMO_MODE) {
 $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-if (isset($_POST['id'])) {
-  $stmt = $pdo->prepare("DELETE FROM materialien WHERE id = ?");
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['id'])) {
+  $stmt = $pdo->prepare("DELETE FROM platten WHERE id = ?");
   $stmt->execute([$_POST['id']]);
   echo "OK";
 }


### PR DESCRIPTION
## Summary
- send POST requests from admin.js when deleting entries
- fix `delete_platte.php` to remove plate records
- only process deletions on POST for both endpoints

## Testing
- `php` not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68401e767cb8832798906e63a18415ca