### PR TITLE
Use PNG logo and add ImageSVG fallback

### DIFF
--- a/export_pdf.php
+++ b/export_pdf.php
@@ -19,21 +19,29 @@ $pdf->addPage();
 // Logo einbinden: SVG bevorzugt, sonst PNG
 $logoSvg = __DIR__ . '/dryba_logo_100.svg';
 $logoPng = __DIR__ . '/dryba_logo_100.png';
+$svgOk = false;
 if (file_exists($logoSvg) && method_exists($pdf, 'ImageSVG')) {
-    // SVG einbinden
-    $pdf->ImageSVG(
-        $file = $logoSvg,
-        $x = 15,
-        $y = 10,
-        $w = 40,
-        $h = 0,
-        $link = '',
-        $align = '',
-        $palign = '',
-        $border = 0,
-        $fitonpage = true
-    );
-} elseif (file_exists($logoPng)) {
+    try {
+        // SVG einbinden
+        $pdf->ImageSVG(
+            $file = $logoSvg,
+            $x = 15,
+            $y = 10,
+            $w = 40,
+            $h = 0,
+            $link = '',
+            $align = '',
+            $palign = '',
+            $border = 0,
+            $fitonpage = true
+        );
+        $svgOk = true;
+    } catch (Exception $e) {
+        $svgOk = false;
+    }
+}
+
+if (!$svgOk && file_exists($logoPng)) {
     // PNG-Fallback
     $pdf->Image(
         $logoPng,

--- a/header.php
+++ b/header.php
@@ -41,7 +41,7 @@
 </head>
 <body>
   <div class="top-nav">
-    <img src="dryba_logo_100.svg" alt="Dryba Logo" class="logo">
+    <img src="dryba_logo_100.png" alt="Dryba Logo" class="logo">
     <a href="index.php">🏠 Startseite</a>
     <a href="zerspanung.php">🧮 Zerspanung</a>
     <a href="admin.php">⚙️ Admin</a>

--- a/login.php
+++ b/login.php
@@ -131,7 +131,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 <body>
   <div class="top-nav">
-    <img src="dryba_logo_100.svg" alt="Dryba Logo" class="logo">
+    <img src="dryba_logo_100.png" alt="Dryba Logo" class="logo">
     <a href="index.html">🏠 Startseite</a>
     <a href="register.php">📝 Registrieren</a>
   </div>


### PR DESCRIPTION
## Summary
- switch logo to PNG on login and header for smaller assets
- embed PDF logo with ImageSVG wrapped in try/catch
- fall back to `$pdf->Image()` with PNG if SVG fails

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401eca46608327b50695a420c11419