### PR TITLE
Enable user management actions

### DIFF
--- a/admin_user.php
+++ b/admin_user.php
@@ -4,10 +4,62 @@
   include 'header.php';
   require 'session_check.php';
   require 'config.php';
+
+  $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
+  $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
   if ($_SESSION['rolle'] !== 'admin') {
       header('Location: index.php');
       exit;
   }
+
+  $meldung = "";
+
+  if (isset($_POST['neuer_benutzer'])) {
+      $stmt = $pdo->prepare("INSERT INTO users (username, password_hash, rolle) VALUES (?, ?, ?)");
+      $stmt->execute([
+          $_POST['username'],
+          password_hash($_POST['password'], PASSWORD_DEFAULT),
+          $_POST['rolle']
+      ]);
+  }
+
+  if (isset($_POST['edit_benutzer'])) {
+      $id = $_POST['id'];
+      $rolle = $_POST['rolle'];
+      $pass = trim($_POST['password'] ?? '');
+
+      if ($pass !== '') {
+          $hash = password_hash($pass, PASSWORD_DEFAULT);
+          $stmt = $pdo->prepare("UPDATE users SET rolle = ?, password_hash = ? WHERE id = ?");
+          $stmt->execute([$rolle, $hash, $id]);
+      } else {
+          $stmt = $pdo->prepare("UPDATE users SET rolle = ? WHERE id = ?");
+          $stmt->execute([$rolle, $id]);
+      }
+  }
+
+  if (isset($_POST['loeschen'])) {
+      if (defined('DEMO_MODE') && DEMO_MODE) {
+          $meldung = "🚫 Löschen im Demo-Modus nicht erlaubt.";
+      } else {
+          $id = $_POST['id'];
+          $stmt = $pdo->prepare("SELECT rolle FROM users WHERE id = ?");
+          $stmt->execute([$id]);
+          $rolle = $stmt->fetchColumn();
+
+          $adminCount = $pdo->query("SELECT COUNT(*) FROM users WHERE rolle = 'admin'")->fetchColumn();
+
+          if ($rolle === 'admin' && $adminCount <= 1) {
+              $meldung = "⚠️ Mindestens ein Admin muss vorhanden sein.";
+          } else {
+              $stmt = $pdo->prepare("DELETE FROM users WHERE id = ?");
+              $stmt->execute([$id]);
+          }
+      }
+  }
+
+  $nutzer = $pdo->query("SELECT id, username, rolle FROM users ORDER BY username")->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <style>
     body { background: #0a0f14; color: #e0e1dd; font-family: sans-serif; max-width: 800px; margin: auto; padding-top: 40px; }
@@ -17,9 +69,13 @@
     th, td { padding: 10px; border: 1px solid #778da9; vertical-align: top; }
     .top-nav a { margin-right: 10px; color: #00b4d8; text-decoration: none; font-weight: bold; }
     h2 { margin-bottom: 10px; }
+    .info { margin-bottom: 15px; font-weight: bold; }
   </style>
 
   <h2>Benutzerverwaltung</h2>
+  <?php if ($meldung): ?>
+    <p class="info"><?= htmlspecialchars($meldung) ?></p>
+  <?php endif; ?>
 
   <form method="post">
     <input type="text" name="username" placeholder="Benutzername" required>


### PR DESCRIPTION
## Summary
- add missing DB connection and form handling to `admin_user.php`
- handle adding, editing and deleting users
- always load current users for the table

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409c4b57988327b835baf7f343752c