### PR TITLE
Return 405 when deletion endpoints called with non‑POST method

### DIFF
--- a/delete_material.php
+++ b/delete_material.php
@@ -2,6 +2,11 @@
 require 'session_check.php';
 require 'config.php';
 
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
 if (defined('DEMO_MODE') && DEMO_MODE) {
   echo "🚫 Löschen im Demo-Modus nicht erlaubt.";
   exit;

--- a/delete_platte.php
+++ b/delete_platte.php
@@ -2,6 +2,11 @@
 require 'session_check.php';
 require 'config.php';
 
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
 if (defined('DEMO_MODE') && DEMO_MODE) {
   echo "🚫 Löschen im Demo-Modus nicht erlaubt.";
   exit;


### PR DESCRIPTION
## Summary
- enforce POST requests in `delete_material.php` and `delete_platte.php`

## Testing
- `php -l delete_material.php` *(fails: `php: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_68409c64074c83278791ce7fc5a2999f