### PR TITLE
Fix session login variable

### DIFF
--- a/login.php
+++ b/login.php
@@ -6,7 +6,7 @@ require 'config.php';
 session_start();
 
 // Bereits eingeloggt? Dann weiter zur Zerspanung (HTML-Datei)
-if (isset($_SESSION['user_id'])) {
+if (isset($_SESSION['username'])) {
     header('Location: zerspanung.php');
     exit;
 }
@@ -36,7 +36,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt->bind_result($id, $hash, $rolle);
 
             if ($stmt->fetch() && password_verify($password, $hash)) {
-                $_SESSION['user_id']   = $id;
                 $_SESSION['username']  = $username;
                 $_SESSION['rolle']     = $rolle;
                 header('Location: zerspanung.php');

--- a/session_check.php
+++ b/session_check.php
@@ -8,7 +8,7 @@ if (session_status() === PHP_SESSION_NONE) {
 }
 
 // Wenn kein Login, zurück zur Login-Seite
-if (empty($_SESSION['user_id'])) {
+if (empty($_SESSION['username'])) {
     header('Location: login.php');
     exit;
 }


### PR DESCRIPTION
## Summary
- switch login check to use `$_SESSION['username']`
- rely on the same key in `session_check.php`

## Testing
- `php -l login.php && php -l session_check.php && php -l profil.php`

------
https://chatgpt.com/codex/tasks/task_e_68409c608b688327aac766e9adff008a