### PR TITLE
Fix duplicate session check in admin_user

### DIFF
--- a/admin_user.php
+++ b/admin_user.php
@@ -2,7 +2,6 @@
   define('REQUIRE_SESSION', true);
   $pageTitle = 'Benutzerverwaltung';
   include 'header.php';
-  require 'session_check.php';
   require 'config.php';
 
   $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);


### PR DESCRIPTION
## Summary
- remove second `require 'session_check.php'` in `admin_user.php`

## Testing
- `php -l admin_user.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5de98dc83279e1bd81f0d845efc