### PR TITLE
Update milling calculator feed options

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -116,6 +116,7 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
     <input type="text" placeholder="Bezeichnung" id="frae_name">
     <input type="text" placeholder="Typ" id="frae_typ">
     <input type="number" placeholder="Zähne" id="frae_z">
+    <input type="number" placeholder="Ø (mm)" id="frae_d">
     <input type="number" placeholder="Empf. vc" id="frae_vc">
     <input type="number" placeholder="Empf. fz" id="frae_fz" step="0.01">
     <div class="checkboxes">
@@ -129,7 +130,7 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
     <button type="button" onclick="saveFraeser()">Speichern</button>
   </form>
   <table id="fraeserTable">
-    <thead><tr><th>Name</th><th>Typ</th><th>Zähne</th><th>vc</th><th>fz</th><th>Gruppen</th><th>Aktion</th></tr></thead>
+    <thead><tr><th>Name</th><th>Typ</th><th>Zähne</th><th>Ø</th><th>vc</th><th>fz</th><th>Gruppen</th><th>Aktion</th></tr></thead>
     <tbody></tbody>
   </table>
 
@@ -235,6 +236,7 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
       formData.append('name', document.getElementById("frae_name").value);
       formData.append('typ', document.getElementById("frae_typ").value);
       formData.append('zaehne', document.getElementById("frae_z").value);
+      formData.append('durchmesser', document.getElementById("frae_d").value);
       formData.append('vc', document.getElementById("frae_vc").value);
       formData.append('fz', document.getElementById("frae_fz").value);
       const gruppen = Array.from(document.querySelectorAll("#fraeserForm .checkboxes input:checked")).map(cb => cb.value).join(',');
@@ -255,6 +257,7 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
       document.getElementById("frae_name").value = f.name;
       document.getElementById("frae_typ").value = f.typ;
       document.getElementById("frae_z").value = f.zaehne;
+      document.getElementById("frae_d").value = f.durchmesser;
       document.getElementById("frae_vc").value = f.vc;
       document.getElementById("frae_fz").value = f.fz;
       document.querySelectorAll("#fraeserForm .checkboxes input").forEach(cb => {
@@ -266,7 +269,7 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
       const tbody = document.querySelector("#fraeserTable tbody");
       tbody.innerHTML = "";
       fr.forEach(f => {
-        tbody.innerHTML += `<tr><td>${f.name}</td><td>${f.typ}</td><td>${f.zaehne}</td><td>${f.vc}</td><td>${f.fz}</td><td>${f.gruppen}</td><td><button onclick='editFraeser(${JSON.stringify(f)})'>Bearbeiten</button> <button onclick="deleteFraeser(${f.id})">Löschen</button></td></tr>`;
+        tbody.innerHTML += `<tr><td>${f.name}</td><td>${f.typ}</td><td>${f.zaehne}</td><td>${f.durchmesser}</td><td>${f.vc}</td><td>${f.fz}</td><td>${f.gruppen}</td><td><button onclick='editFraeser(${JSON.stringify(f)})'>Bearbeiten</button> <button onclick="deleteFraeser(${f.id})">Löschen</button></td></tr>`;
       });
     }
 

--- a/beispieldaten.sql
+++ b/beispieldaten.sql
@@ -18,9 +18,9 @@ INSERT INTO platten (name, typ, gruppen, vc) VALUES
 ('MGMT150408-PM YBC251', 'MGMT150408', 'P,M,K', 140);
 
 -- Beispiel-Fräser
-INSERT INTO fraeser (name, typ, zaehne, gruppen, vc, fz) VALUES
-('3-Schneider \xC3\x9810', 'VHM-Schaftfräser', 3, 'P,M,K,N', 120, 0.05),
-('4-Schneider \xC3\x988', 'HSS-Schaftfräser', 4, 'P,M,K', 60, 0.04);
+INSERT INTO fraeser (name, typ, zaehne, durchmesser, gruppen, vc, fz) VALUES
+('3-Schneider \xC3\x9810', 'VHM-Schaftfräser', 3, 10, 'P,M,K,N', 120, 0.05),
+('4-Schneider \xC3\x988', 'HSS-Schaftfräser', 4, 8, 'P,M,K', 60, 0.04);
 
 -- Demo-Benutzer mit Rolle viewer
 INSERT IGNORE INTO users (username, password_hash, rolle) VALUES (

--- a/install.php
+++ b/install.php
@@ -91,6 +91,7 @@ $tables = [
     name VARCHAR(100),
     typ VARCHAR(50),
     zaehne INT,
+    durchmesser FLOAT,
     gruppen VARCHAR(20),
     vc FLOAT,
     fz FLOAT

--- a/load.php
+++ b/load.php
@@ -21,7 +21,7 @@ $platt_stmt = $pdo->query("SELECT id, name, typ, gruppen, vc FROM platten ORDER 
 $data["platten"] = $platt_stmt->fetchAll(PDO::FETCH_ASSOC);
 
 // Fräserdaten laden
-$fraes_stmt = $pdo->query("SELECT id, name, typ, zaehne, gruppen, vc, fz FROM fraeser ORDER BY name");
+$fraes_stmt = $pdo->query("SELECT id, name, typ, zaehne, durchmesser, gruppen, vc, fz FROM fraeser ORDER BY name");
 $data["fraeser"] = $fraes_stmt->fetchAll(PDO::FETCH_ASSOC);
 
 echo json_encode($data);

--- a/save_fraeser.php
+++ b/save_fraeser.php
@@ -18,11 +18,12 @@ if (isset($_POST['loeschen'])) {
 // INSERT oder UPDATE
 if (!empty($_POST['id'])) {
   // UPDATE
-  $stmt = $pdo->prepare("UPDATE fraeser SET name=?, typ=?, zaehne=?, gruppen=?, vc=?, fz=? WHERE id=?");
+  $stmt = $pdo->prepare("UPDATE fraeser SET name=?, typ=?, zaehne=?, durchmesser=?, gruppen=?, vc=?, fz=? WHERE id=?");
   $stmt->execute([
     $_POST['name'],
     $_POST['typ'],
     $_POST['zaehne'],
+    $_POST['durchmesser'],
     $_POST['gruppen'],
     $_POST['vc'],
     $_POST['fz'],
@@ -30,11 +31,12 @@ if (!empty($_POST['id'])) {
   ]);
 } else {
   // INSERT
-  $stmt = $pdo->prepare("INSERT INTO fraeser (name, typ, zaehne, gruppen, vc, fz) VALUES (?, ?, ?, ?, ?, ?)");
+  $stmt = $pdo->prepare("INSERT INTO fraeser (name, typ, zaehne, durchmesser, gruppen, vc, fz) VALUES (?, ?, ?, ?, ?, ?, ?)");
   $stmt->execute([
     $_POST['name'],
     $_POST['typ'],
     $_POST['zaehne'],
+    $_POST['durchmesser'],
     $_POST['gruppen'],
     $_POST['vc'],
     $_POST['fz']


### PR DESCRIPTION
## Summary
- store tool diameter in database and admin interface
- load and save fräser diameter through API
- remove Schneidstoff & workpiece diameter fields on milling calculator
- add feed-mode dropdown to calculate vf or fz accordingly
- use selected tool diameter for speed calculations

## Testing
- `php` not installed in container so no tests run

------
https://chatgpt.com/codex/tasks/task_e_6840ade7560083278e22c30a140ea5e0