### PR TITLE
Handle vf export mode

### DIFF
--- a/export_csv.php
+++ b/export_csv.php
@@ -8,11 +8,19 @@ header('Content-Disposition: attachment; filename="zerspanung_export.csv"');
 
 $output = fopen('php://output', 'w');
 // Spaltenüberschriften
+$feedLabel = 'f oder fz';
+if (isset($_SESSION['export']['fz'])) {
+    $feedLabel = 'fz (mm/Zahn)';
+} elseif (isset($_SESSION['export']['f'])) {
+    $feedLabel = 'f (mm/U)';
+} elseif (isset($_SESSION['export']['vf'])) {
+    $feedLabel = 'vf (mm/min)';
+}
 fputcsv($output, [
   'Material',
   'Werkzeug',
   'vc (m/min)',
-  'f oder fz',
+  $feedLabel,
   'ap (mm)',
   'Durchmesser (mm)',
   'Spindeldrehzahl (U/min)',
@@ -38,6 +46,7 @@ if (!isset($data['fraeser']) && isset($data['platte'])) {
 if (!isset($data['fz']) && isset($data['f'])) {
     $data['fz'] = $data['f'];
 }
+$feedValue = $data['fz'] ?? ($data['f'] ?? ($data['vf'] ?? ''));
 
 // Wenn Daten da sind, in die CSV schreiben, sonst Fehlermeldung
 if (!empty($data)) {
@@ -45,7 +54,7 @@ if (!empty($data)) {
     $data['material']   ?? '',
     $data['fraeser']    ?? ($data['platte'] ?? ''),
     $data['vc']         ?? '',
-    $data['fz']         ?? ($data['f'] ?? ''),
+    $feedValue,
     $data['ap']         ?? '',
     $data['D']          ?? '',
     $data['n']          ?? '',

--- a/export_excel.php
+++ b/export_excel.php
@@ -13,11 +13,23 @@ $sheet->setTitle('Zerspanung');
 $sheet->setCellValue('A1', 'Bezeichnung');
 $sheet->setCellValue('B1', 'Wert');
 
+$feedLabel = 'f oder fz';
+$feedKey = 'fz';
+if (isset($data['fz'])) {
+    $feedLabel = 'fz (mm/Zahn)';
+    $feedKey = 'fz';
+} elseif (isset($data['f'])) {
+    $feedLabel = 'f (mm/U)';
+    $feedKey = 'f';
+} elseif (isset($data['vf'])) {
+    $feedLabel = 'vf (mm/min)';
+    $feedKey = 'vf';
+}
 $labels = [
   'Material' => 'material',
   'Werkzeug' => 'fraeser',
   'vc (m/min)' => 'vc',
-  'f oder fz' => 'fz',
+  $feedLabel => $feedKey,
   'ap (mm)' => 'ap',
   'Durchmesser (mm)' => 'D',
   'Spindeldrehzahl (U/min)' => 'n',

--- a/export_pdf.php
+++ b/export_pdf.php
@@ -86,11 +86,23 @@ $pdf->Ln(5);
 // Tabelle mit Daten
 $pdf->SetFont('helvetica', '', 12);
 $html = '<table cellpadding="4">';
+$feedLabel = 'f oder fz';
+$feedValue = '-';
+if (isset($data['fz'])) {
+    $feedLabel = 'fz (mm/Zahn)';
+    $feedValue = $data['fz'];
+} elseif (isset($data['f'])) {
+    $feedLabel = 'f (mm/U)';
+    $feedValue = $data['f'];
+} elseif (isset($data['vf'])) {
+    $feedLabel = 'vf (mm/min)';
+    $feedValue = $data['vf'];
+}
 $labels = [
     'Material'                 => $data['material'] ?? '-',
     'Werkzeug'                 => $data['fraeser'] ?? ($data['platte'] ?? '-'),
     'vc (m/min)'               => $data['vc'] ?? '-',
-    'f oder fz'                => $data['fz'] ?? ($data['f'] ?? '-'),
+    $feedLabel                 => $feedValue,
     'ap (mm)'                  => $data['ap'] ?? '-',
     'Durchmesser (mm)'         => $data['D'] ?? '-',
     'Spindeldrehzahl'          => isset($data['n']) ? $data['n'] . ' U/min' : '-',

--- a/session_export.php
+++ b/session_export.php
@@ -4,7 +4,12 @@ session_start();
 $data = json_decode(file_get_contents("php://input"), true);
 
 if (is_array($data)) {
-  $_SESSION['export'] = $data;
+  // vorhandene Exportdaten beibehalten und um neue Werte ergaenzen
+  $_SESSION['export'] = array_merge($_SESSION['export'] ?? [], $data);
+  // Vorsorglich vf separat speichern, falls dieser Feed-Modus verwendet wird
+  if (isset($data['vf'])) {
+    $_SESSION['export']['vf'] = $data['vf'];
+  }
   http_response_code(200);
   echo json_encode(["status" => "ok"]);
 } else {


### PR DESCRIPTION
## Summary
- preserve previous export data and save vf in `session_export.php`
- export feed label based on supplied data for PDF, Excel and CSV

## Testing
- `php -l session_export.php`
- `php -l export_pdf.php`
- `php -l export_excel.php`
- `php -l export_csv.php`


------
https://chatgpt.com/codex/tasks/task_e_6840ade9a79c8327a312e1802c5abe42