### PR TITLE
Add feed mode dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sudo apt install composer
 | `session_export.php` | Speichert Berechnungsdaten für Export    |
 ### Vorschubmodus wählen
 
-Im Rechner wählst du über ein Dropdown zwischen `fz` (mm/Zahn), `f` (mm/U) und `vf` (mm/min). Der Export übernimmt immer den aktuell gewählten Modus.
+Direkt beim Eingabefeld für den Vorschub findest du ein Dropdown zur Wahl des Modus `fz`, `f` oder `vf`. Der Labeltext passt sich entsprechend an und der eingegebene Wert wird als Vorschub pro Zahn, pro Umdrehung oder als Vorschubgeschwindigkeit interpretiert. Wählst du `fz` und änderst den Fräser, wird automatisch der empfohlene fz-Wert aus der Datenbank geladen. Der Export speichert alle drei Werte und verwendet den aktuell aktiven Modus.
 
 
 ## 📦 Beispieldaten

--- a/session_export.php
+++ b/session_export.php
@@ -6,9 +6,11 @@ $data = json_decode(file_get_contents("php://input"), true);
 if (is_array($data)) {
   // vorhandene Exportdaten beibehalten und um neue Werte ergaenzen
   $_SESSION['export'] = array_merge($_SESSION['export'] ?? [], $data);
-  // Vorsorglich vf separat speichern, falls dieser Feed-Modus verwendet wird
-  if (isset($data['vf'])) {
-    $_SESSION['export']['vf'] = $data['vf'];
+  // Vorsorglich alle Feed-Werte separat speichern
+  foreach (['fz', 'f', 'vf'] as $key) {
+    if (isset($data[$key])) {
+      $_SESSION['export'][$key] = $data[$key];
+    }
   }
   http_response_code(200);
   echo json_encode(["status" => "ok"]);


### PR DESCRIPTION
## Summary
- add dropdown to choose between feed per tooth, revolution or speed
- compute fz/f/vf from selected mode
- store all feed values in session for exports
- auto-fill fz value from tool when mode `fz`
- document new feed mode UI

## Testing
- `php -l fraesen.php` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841297751b88327b8509e852370e606