### PR TITLE
Add UI toggle for login system

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,7 +35,7 @@ Hinweis: Die Tabelle `fraeser` enthält jetzt die Spalte `durchmesser` zur Ablag
    - Neuen Admin anlegen
    - Demo-Admin löschen
 
-Die Einstellung kann jederzeit in `config.php` über `LOGIN_REQUIRED` angepasst werden.
+Die Einstellung kann später über die Einstellungen (`settings.php`) oder `LOGIN_REQUIRED` in `config.php` angepasst werden.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ein interaktiver Zerspanungsrechner mit Material- und Werkzeugdatenbank, Benutze
 - 📝 Selbstregistrierung über `register.php` (automatisch `viewer`)
 - ⚠️ Schutz: Letzter Admin kann nicht gelöscht werden
 - 🛠 Webbasierter Installationsassistent (`install.php`)
-- 🔑 Login-Pflicht lässt sich über `LOGIN_REQUIRED` in `config.php` steuern
+- 🔑 Login-Pflicht lässt sich über die Einstellungen (`settings.php`) oder `LOGIN_REQUIRED` in `config.php` steuern
 - 🧭 Navigation über alle Seiten integriert
 - 🔄 Dropdown für den Vorschubmodus (fz / f / vf) im Rechner
 - 👥 Admin-Bereich zum Verwalten von Materialien, Schneidplatten und Fräsern
@@ -29,7 +29,7 @@ Ein interaktiver Zerspanungsrechner mit Material- und Werkzeugdatenbank, Benutze
 3. **Datenbankzugangsdaten eingeben**
 4. **Benutzerverwaltung aktivieren?** (Login-Pflicht)
 5. **Admin-Benutzer anlegen und Demo-Admin entfernen** (nur bei aktivierter Benutzerverwaltung)
-   - Die Einstellung kann später über `LOGIN_REQUIRED` in `config.php` geändert werden
+   - Die Einstellung kann später über die Einstellungen (`settings.php`) oder `LOGIN_REQUIRED` in `config.php` geändert werden
 
 ## 🛠️ Erforderliche Erweiterungen
 

--- a/header.php
+++ b/header.php
@@ -47,6 +47,7 @@
     <a href="zerspanung.php">🤖 Drehbank</a>
     <a href="fraesen.php">🛠️ Fräsen</a>
     <a href="admin.php">⚙️ Admin</a>
+    <a href="settings.php">🔧 Einstellungen</a>
     <?php if (LOGIN_REQUIRED): ?>
       <a href="admin_user.php">👥 Benutzer</a>
       <a href="profil.php">👤 Profil</a>

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,49 @@
+<?php
+require_once 'config.php';
+if (LOGIN_REQUIRED) {
+    define('REQUIRE_SESSION', true);
+}
+$pageTitle = 'Einstellungen';
+include 'header.php';
+if (LOGIN_REQUIRED) {
+    require 'session_check.php';
+    if ($_SESSION['rolle'] !== 'admin') {
+        die('Zugriff verweigert');
+    }
+}
+
+$meldung = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $aktiv = isset($_POST['login_required']);
+    $config = file_get_contents('config.php');
+    if ($config !== false) {
+        $newVal = $aktiv ? 'true' : 'false';
+        $config = preg_replace("/define\('LOGIN_REQUIRED',\s*(true|false)\);/", "define('LOGIN_REQUIRED', $newVal);", $config);
+        if (file_put_contents('config.php', $config) !== false) {
+            $meldung = 'Einstellungen gespeichert.';
+            define('LOGIN_REQUIRED', $aktiv);
+        } else {
+            $meldung = 'Fehler beim Schreiben der config.php';
+        }
+    } else {
+        $meldung = 'config.php nicht gefunden';
+    }
+}
+?>
+<style>
+  body { background:#0a0f14; color:#e0e1dd; font-family:sans-serif; max-width:600px; margin:auto; padding-top:40px; }
+  form { margin-top:20px; }
+  label { display:block; margin-bottom:10px; font-weight:bold; }
+  button { padding:10px; background:#00b4d8; color:#000; border:none; font-weight:bold; border-radius:4px; }
+  .info { margin-top:15px; font-weight:bold; }
+</style>
+<h2>⚙️ Einstellungen</h2>
+<?php if ($meldung): ?>
+<p class="info"><?= htmlspecialchars($meldung) ?></p>
+<?php endif; ?>
+<form method="post">
+  <label><input type="checkbox" name="login_required" <?= LOGIN_REQUIRED ? 'checked' : '' ?>> Login/Benutzerverwaltung aktiv</label>
+  <button type="submit">Speichern</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `settings.php` page to turn the login requirement on/off
- show link to settings page in navigation
- document that the login can be toggled via `settings.php`

## Testing
- `php -l settings.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c840a6de083278df3292860a3c70b