### PR TITLE
Add example config and ignore personal config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.php

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,8 +14,9 @@
 ```bash
 sudo chown -R www-data:www-data /var/www/html/drehbank
 ```
+2. `config.example.php` nach `config.php` kopieren und anpassen. Wer die Datei lokal weiter versionieren möchte, kann `git update-index --skip-worktree config.php` verwenden.
 
-2. Optional: Rechte für Konfigdatei:
+3. Optional: Rechte für Konfigdatei:
 ```bash
 chmod 640 /var/www/html/drehbank/config.php
 ```

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Ein interaktiver Zerspanungsrechner mit Material- und Werkzeugdatenbank, Benutze
 ## 🚀 Installation
 
 1. **Dateien hochladen** nach `/var/www/html/drehbank`
-2. **Installer starten**:
+2. Kopiere `config.example.php` zu `config.php` und passe es bei Bedarf an. Optional kannst du `git update-index --skip-worktree config.php` verwenden, wenn die Datei lokal verfolgt bleiben soll.
+3. **Installer starten**:
    `https://DEIN_SERVER/drehbank/install.php`
-3. **Datenbankzugangsdaten eingeben**
-4. **Benutzerverwaltung aktivieren?** (Login-Pflicht)
-5. **Admin-Benutzer anlegen und Demo-Admin entfernen** (nur bei aktivierter Benutzerverwaltung)
+4. **Datenbankzugangsdaten eingeben**
+5. **Benutzerverwaltung aktivieren?** (Login-Pflicht)
+6. **Admin-Benutzer anlegen und Demo-Admin entfernen** (nur bei aktivierter Benutzerverwaltung)
    - Die Einstellung kann später über die Einstellungen (`settings.php`) oder `LOGIN_REQUIRED` in `config.php` geändert werden
 
 ## 🛠️ Erforderliche Erweiterungen

--- a/config.example.php
+++ b/config.example.php
@@ -1,4 +1,5 @@
 <?php
+// Beispielkonfiguration, nach Bedarf anpassen
 
 define('DEMO_MODE', false);  // Demo-Modus aktiv: kein Löschen möglich
 define('LOGIN_REQUIRED', true); // Wenn false, ist kein Login nötig


### PR DESCRIPTION
## Summary
- provide `config.example.php`
- ignore local `config.php`
- document copying the example config in installation guides

## Testing
- `php -l config.example.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8f38365c8327a0d7a55ca3c7f434