### PR TITLE
Update installer docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,10 @@
 ```bash
 sudo chown -R www-data:www-data /var/www/html/drehbank
 ```
-2. `config.example.php` nach `config.php` kopieren und anpassen. Wer die Datei lokal weiter versionieren möchte, kann `git update-index --skip-worktree config.php` verwenden.
+2. **Installer starten**:
+   `http://DEIN_SERVER/drehbank/install.php`
+   - Erstellt `config.php`, falls sie fehlt. Kopiere also keine Example-Datei vorab oder lösche/benenne vorhandene Kopien, damit der Installer neue Zugangsdaten schreiben kann.
+   - Wer die Datei lokal weiter versionieren möchte, kann danach `git update-index --skip-worktree config.php` verwenden.
 
 3. Optional: Rechte für Konfigdatei:
 ```bash
@@ -37,6 +40,8 @@ Hinweis: Die Tabelle `fraeser` enthält jetzt die Spalte `durchmesser` zur Ablag
    - Demo-Admin löschen
 
 Die Einstellung kann später über die Einstellungen (`settings.php`) oder `LOGIN_REQUIRED` in `config.php` angepasst werden.
+
+*(Fallback)* Sollte der Installer nicht zur Verfügung stehen, kopiere `config.example.php` manuell zu `config.php` und passe die Werte an.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ Ein interaktiver Zerspanungsrechner mit Material- und Werkzeugdatenbank, Benutze
 ## 🚀 Installation
 
 1. **Dateien hochladen** nach `/var/www/html/drehbank`
-2. Kopiere `config.example.php` zu `config.php` und passe es bei Bedarf an. Optional kannst du `git update-index --skip-worktree config.php` verwenden, wenn die Datei lokal verfolgt bleiben soll.
-3. **Installer starten**:
+2. **Installer starten**:
    `https://DEIN_SERVER/drehbank/install.php`
-4. **Datenbankzugangsdaten eingeben**
-5. **Benutzerverwaltung aktivieren?** (Login-Pflicht)
-6. **Admin-Benutzer anlegen und Demo-Admin entfernen** (nur bei aktivierter Benutzerverwaltung)
+   - Legt `config.php` automatisch an, wenn die Datei fehlt. Kopiere also **nicht** `config.example.php` vorher oder lösche/benenne vorhandene Kopien um, damit der Installer neue Zugangsdaten schreiben kann.
+   - Optional kannst du nach der Installation `git update-index --skip-worktree config.php` verwenden, wenn die Datei lokal weiter versioniert werden soll.
+3. **Datenbankzugangsdaten eingeben**
+4. **Benutzerverwaltung aktivieren?** (Login-Pflicht)
+5. **Admin-Benutzer anlegen und Demo-Admin entfernen** (nur bei aktivierter Benutzerverwaltung)
    - Die Einstellung kann später über die Einstellungen (`settings.php`) oder `LOGIN_REQUIRED` in `config.php` geändert werden
+6. *(Fallback)* Sollte der Installer nicht genutzt werden können, kopiere `config.example.php` manuell zu `config.php` und passe die Werte an.
 
 ## 🛠️ Erforderliche Erweiterungen
 


### PR DESCRIPTION
## Summary
- document that `install.php` creates `config.php` automatically
- warn against copying `config.example.php` before running installer
- show copying the example file only as a fallback manual setup step

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca080c6248327af11d22554ea755f