### PR TITLE
Add config existence check

### DIFF
--- a/admin_user.php
+++ b/admin_user.php
@@ -2,7 +2,7 @@
   define('REQUIRE_SESSION', true);
   $pageTitle = 'Benutzerverwaltung';
   include 'header.php';
-  require 'config.php';
+  require 'require_config.php';
 
   $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/delete_fraeser.php
+++ b/delete_fraeser.php
@@ -1,6 +1,6 @@
 <?php
 require 'session_check.php';
-require 'config.php';
+require 'require_config.php';
 
 if (defined('DEMO_MODE') && DEMO_MODE) {
   echo "🚫 Löschen im Demo-Modus nicht erlaubt.";

--- a/delete_material.php
+++ b/delete_material.php
@@ -1,6 +1,6 @@
 <?php
 require 'session_check.php';
-require 'config.php';
+require 'require_config.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);

--- a/delete_platte.php
+++ b/delete_platte.php
@@ -1,6 +1,6 @@
 <?php
 require 'session_check.php';
-require 'config.php';
+require 'require_config.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);

--- a/header.php
+++ b/header.php
@@ -1,5 +1,5 @@
 <?php
-  require_once 'config.php';
+  require_once 'require_config.php';
   // Für Seiten, die Session-Handling benötigen:
   if (defined('REQUIRE_SESSION')) {
     require 'session_check.php';

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-  require_once 'config.php';
+  require_once 'require_config.php';
   // Für Seiten, die Session-Handling benötigen:
   if (defined('REQUIRE_SESSION')) {
     require 'session_check.php';

--- a/load.php
+++ b/load.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'require_config.php';
 
 $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/login.php
+++ b/login.php
@@ -2,7 +2,7 @@
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
-require 'config.php';
+require 'require_config.php';
 session_start();
 
 // Bereits eingeloggt? Dann weiter zur Zerspanung (HTML-Datei)

--- a/pdf_preview.php
+++ b/pdf_preview.php
@@ -27,7 +27,7 @@ $save_success = false;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (isset($_POST['save'])) {
     if (!empty($_POST['werkstoff'])) {
-      require 'config.php';
+      require 'require_config.php';
       $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
       $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/profil.php
+++ b/profil.php
@@ -3,7 +3,7 @@
   $pageTitle = 'Mein Profil';
   include 'header.php';
 require 'session_check.php';
-require 'config.php';
+require 'require_config.php';
 
 // Logged in user's name
 $currentUser = $_SESSION['username'];

--- a/register.php
+++ b/register.php
@@ -2,7 +2,7 @@
   // define('REQUIRE_SESSION', true);
   $pageTitle = 'Registrieren';
   include 'header.php';
-require 'config.php';
+require 'require_config.php';
 $meldung = "";
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/require_config.php
+++ b/require_config.php
@@ -1,0 +1,8 @@
+<?php
+$cfg = __DIR__ . '/config.php';
+if (!file_exists($cfg)) {
+    echo "Bitte install.php ausführen, um config.php anzulegen.";
+    exit;
+}
+require_once $cfg;
+?>

--- a/save_fraeser.php
+++ b/save_fraeser.php
@@ -1,6 +1,6 @@
 <?php
 require 'session_check.php';
-require 'config.php';
+require 'require_config.php';
 
 $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/save_material.php
+++ b/save_material.php
@@ -1,6 +1,6 @@
 <?php
 require 'session_check.php';
-require 'config.php';
+require 'require_config.php';
 
 $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/save_platte.php
+++ b/save_platte.php
@@ -1,6 +1,6 @@
 <?php
 require 'session_check.php';
-require 'config.php';
+require 'require_config.php';
 
 $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/session_check.php
+++ b/session_check.php
@@ -4,7 +4,7 @@
 // und vermeidet doppelte session_start()-Aufrufe.
 
 if (!defined('LOGIN_REQUIRED')) {
-    require 'config.php';
+    require 'require_config.php';
 }
 
 if (session_status() === PHP_SESSION_NONE) {

--- a/settings.php
+++ b/settings.php
@@ -1,5 +1,5 @@
 <?php
-require_once 'config.php';
+require_once 'require_config.php';
 if (LOGIN_REQUIRED) {
     define('REQUIRE_SESSION', true);
 }

--- a/update.php
+++ b/update.php
@@ -1,5 +1,5 @@
 <?php
-  require 'config.php';
+  require 'require_config.php';
   if (LOGIN_REQUIRED) {
     define('REQUIRE_SESSION', true);
   }
@@ -23,7 +23,7 @@
   </form>
 <?php
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
-  require 'config.php';
+  require 'require_config.php';
   $pdo = new PDO("mysql:host=$host;dbname=$db", $user, $pass);
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
   $res = $pdo->query("SHOW COLUMNS FROM fraeser LIKE 'durchmesser'");


### PR DESCRIPTION
## Summary
- add a require_config.php helper that checks for `config.php`
- use the helper in all entry points

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6ac8c2808327956eb37f9899a8db