### PR TITLE
Ignore composer artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config.php
+vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ composer require phpoffice/phpspreadsheet
 ```bash
 sudo apt install composer
 ```
+Anschließend im Projektordner `composer install` ausführen. Die installierten
+Abhängigkeiten landen im Ordner `vendor/`. Dieser Ordner und die Datei
+`composer.lock` sind in der Versionskontrolle ignoriert.
 
 ## 📂 Dateien & Seiten
 


### PR DESCRIPTION
## Summary
- ignore Composer vendor directory and lock file
- document Composer install step in README

## Testing
- `composer install` *(fails: missing PHP ext-dom)*

------
https://chatgpt.com/codex/tasks/task_e_684d6aba36008327a40d1b5d3d9510b1