### PR TITLE
docs: add system setup instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,20 @@
 - MariaDB oder MySQL
 - Composer (`sudo apt install composer`)
 
+### Systempakete installieren
+
+```bash
+sudo apt update
+sudo apt install apache2 mariadb-server php php-mbstring php-xml php-gd php-zip php-mysql
+```
+
+**Benötigte PHP-Erweiterungen:** `mbstring`, `xml`, `zip`, `gd` – diese werden u. a. von TCPDF und PhpSpreadsheet genutzt.
+
+### Webserver konfigurieren
+
+- **Apache**: VirtualHost für `/var/www/html/drehbank` anlegen und bei Bedarf `AllowOverride All` setzen.
+- **Nginx**: Serverblock mit `root /var/www/html/drehbank;` sowie PHP-FPM-Anbindung konfigurieren.
+
 ---
 
 ## 📂 Projektbereitstellung

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ Ein interaktiver Zerspanungsrechner mit Material- und Werkzeugdatenbank, Benutze
 
 ## 🚀 Installation
 
+### Systempakete installieren
+
+```bash
+sudo apt update
+sudo apt install apache2 mariadb-server php php-mbstring php-xml php-gd php-zip php-mysql
+```
+
+**Benötigte PHP-Erweiterungen:** `mbstring`, `xml`, `zip`, `gd` – erforderlich für TCPDF und PhpSpreadsheet.
+
+### Webserver konfigurieren
+
+- **Apache**: VirtualHost auf `/var/www/html/drehbank` verweisen, ggf. `AllowOverride All` aktivieren.
+- **Nginx**: Serverblock mit `root /var/www/html/drehbank;` und PHP-FPM-Einbindung erstellen.
+
 1. **Dateien hochladen** nach `/var/www/html/drehbank`
 2. **Installer starten**:
    `https://DEIN_SERVER/drehbank/install.php`


### PR DESCRIPTION
## Summary
- document apt install commands for Apache, MariaDB and PHP with required extensions
- note PHP extensions needed by TCPDF/PhpSpreadsheet and basic Apache/Nginx config tips

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_688fc61527f08327a61217dc386f1eb0