### PR TITLE
docs: add database user creation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,12 +14,20 @@
 ```bash
 sudo chown -R www-data:www-data /var/www/html/drehbank
 ```
-2. **Installer starten**:
+2. Datenbank und Benutzer anlegen:
+```sql
+CREATE DATABASE drehbank;
+CREATE USER 'drehuser'@'localhost' IDENTIFIED BY 'starkes-passwort';
+GRANT ALL PRIVILEGES ON drehbank.* TO 'drehuser'@'localhost';
+FLUSH PRIVILEGES;
+```
+   Diese Zugangsdaten müssen im Web‑Installer eingetragen werden.
+3. **Installer starten**:
    `http://DEIN_SERVER/drehbank/install.php`
    - Erstellt `config.php`, falls sie fehlt. Kopiere also keine Example-Datei vorab oder lösche/benenne vorhandene Kopien, damit der Installer neue Zugangsdaten schreiben kann.
    - Wer die Datei lokal weiter versionieren möchte, kann danach `git update-index --skip-worktree config.php` verwenden.
 
-3. Optional: Rechte für Konfigdatei:
+4. Optional: Rechte für Konfigdatei:
 ```bash
 chmod 640 /var/www/html/drehbank/config.php
 ```
@@ -31,7 +39,7 @@ chmod 640 /var/www/html/drehbank/config.php
 1. Browser öffnen:
    `http://DEIN_SERVER/drehbank/install.php`
 
-2. Datenbankzugangsdaten und App-User anlegen
+2. Datenbankzugangsdaten (z. B. `drehuser`) und App-User anlegen
 3. Benutzerverwaltung aktivieren? (setzt `LOGIN_REQUIRED` in `config.php`)
 
 Hinweis: Die Tabelle `fraeser` enthält jetzt die Spalte `durchmesser` zur Ablage des Werkzeug-Ø. Der Installer legt diese Spalte automatisch an.

--- a/README.md
+++ b/README.md
@@ -24,15 +24,23 @@ Ein interaktiver Zerspanungsrechner mit Material- und Werkzeugdatenbank, Benutze
 ## 🚀 Installation
 
 1. **Dateien hochladen** nach `/var/www/html/drehbank`
-2. **Installer starten**:
+2. **Datenbank und Benutzer anlegen**:
+```sql
+CREATE DATABASE drehbank;
+CREATE USER 'drehuser'@'localhost' IDENTIFIED BY 'starkes-passwort';
+GRANT ALL PRIVILEGES ON drehbank.* TO 'drehuser'@'localhost';
+FLUSH PRIVILEGES;
+```
+   Diese Zugangsdaten müssen im Web‑Installer eingetragen werden.
+3. **Installer starten**:
    `https://DEIN_SERVER/drehbank/install.php`
    - Legt `config.php` automatisch an, wenn die Datei fehlt. Kopiere also **nicht** `config.example.php` vorher oder lösche/benenne vorhandene Kopien um, damit der Installer neue Zugangsdaten schreiben kann.
    - Optional kannst du nach der Installation `git update-index --skip-worktree config.php` verwenden, wenn die Datei lokal weiter versioniert werden soll.
-3. **Datenbankzugangsdaten eingeben**
-4. **Benutzerverwaltung aktivieren?** (Login-Pflicht)
-5. **Admin-Benutzer anlegen und Demo-Admin entfernen** (nur bei aktivierter Benutzerverwaltung)
+4. **Datenbankzugangsdaten (z. B. `drehuser`) eingeben**
+5. **Benutzerverwaltung aktivieren?** (Login-Pflicht)
+6. **Admin-Benutzer anlegen und Demo-Admin entfernen** (nur bei aktivierter Benutzerverwaltung)
    - Die Einstellung kann später über die Einstellungen (`settings.php`) oder `LOGIN_REQUIRED` in `config.php` geändert werden
-6. *(Fallback)* Sollte der Installer nicht genutzt werden können, kopiere `config.example.php` manuell zu `config.php` und passe die Werte an.
+7. *(Fallback)* Sollte der Installer nicht genutzt werden können, kopiere `config.example.php` manuell zu `config.php` und passe die Werte an.
 
 ## 🛠️ Erforderliche Erweiterungen
 


### PR DESCRIPTION
## Summary
- explain how to create a dedicated MySQL/MariaDB database user
- mention that the web installer requires these credentials

## Testing
- `composer validate`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688fc615fe388327840e6d977b7cafad