### PR TITLE
Add global DEBUG toggle and centralize PHP error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ committe diese Änderung und ziehe danach die neue Version.
 ## 🔐 Sicherheit
 
 - `config.php` nach Installation per `chmod 640` schützen
+- `DEBUG=false` in `config.php` deaktiviert die Fehlerausgabe und wird für Produktionssysteme empfohlen
 - Standard-Adminkonto `admin/admin123` löschen
 - Admin darf nicht gelöscht werden, wenn letzter seiner Rolle
 

--- a/config.example.php
+++ b/config.example.php
@@ -1,4 +1,5 @@
 <?php
+define('DEBUG', true); // in Produktion auf false setzen
 define('DEMO_MODE', false);
 define('LOGIN_REQUIRED', true);
 

--- a/fraesen.php
+++ b/fraesen.php
@@ -1,7 +1,4 @@
 <?php require 'session_check.php';
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
 include 'header.php';
  ?>
 <!DOCTYPE html>

--- a/install.php
+++ b/install.php
@@ -1,6 +1,12 @@
 <?php
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
+if (file_exists('config.php')) {
+  require 'config.php';
+  if (defined('DEBUG') && DEBUG) {
+    ini_set('display_errors', 1);
+    ini_set('display_startup_errors', 1);
+    error_reporting(E_ALL);
+  }
+}
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 ?>
@@ -146,6 +152,7 @@ $demo_setting = $existing_demo !== null ? $existing_demo : $demo_mode;
 $login_setting = $existing_login !== null ? $existing_login : $login_required;
 $config = <<<PHP
 <?php
+define('DEBUG', false);
 define('DEMO_MODE', $demo_setting);  // Demo-Modus aktiv: kein Löschen möglich
 define('LOGIN_REQUIRED', $login_setting);
 

--- a/login.php
+++ b/login.php
@@ -1,7 +1,4 @@
 <?php
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
 require 'require_config.php';
 session_start();
 

--- a/require_config.php
+++ b/require_config.php
@@ -5,4 +5,14 @@ if (!file_exists($cfg)) {
     exit;
 }
 require_once $cfg;
+
+if (defined('DEBUG') && DEBUG) {
+    ini_set('display_errors', 1);
+    ini_set('display_startup_errors', 1);
+    error_reporting(E_ALL);
+} else {
+    ini_set('display_errors', 0);
+    ini_set('display_startup_errors', 0);
+    error_reporting(0);
+}
 ?>

--- a/zerspanung.php
+++ b/zerspanung.php
@@ -1,7 +1,4 @@
 <?php require 'session_check.php';
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
 include 'header.php';
  ?>
 <style>


### PR DESCRIPTION
## Summary
- Introduce `DEBUG` constant in configuration and centralize error handling in `require_config.php`
- Update installer to write `DEBUG` flag and bind error display to it
- Remove direct `ini_set`/`error_reporting` calls from pages and document production recommendation

## Testing
- `php -l config.example.php`
- `php -l require_config.php`
- `php -l login.php`
- `php -l zerspanung.php`
- `php -l fraesen.php`
- `php -l install.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8bc691bb08327b82554f958f38c55