### PR TITLE
Add CSRF protection across application

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -67,6 +67,7 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
 
   <h2>Materialien verwalten</h2>
   <form id="materialForm">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <input type="hidden" id="mat_id">
     <input type="text" placeholder="Materialname" id="mat_name">
     <input type="text" placeholder="Typ" id="mat_typ">
@@ -90,6 +91,7 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
 
   <h2>Schneidplatten verwalten</h2>
   <form id="platteForm">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <input type="hidden" id="platt_id">
     <input type="text" placeholder="Bezeichnung (z.B. VCMT110304)" id="platt_name">
     <input type="text" placeholder="ISO-Typ (z.B. VCMT)" id="platt_typ">
@@ -112,6 +114,7 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
 
   <h2>Fräser verwalten</h2>
   <form id="fraeserForm">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <input type="hidden" id="frae_id">
     <input type="text" placeholder="Bezeichnung" id="frae_name">
     <input type="text" placeholder="Typ" id="frae_typ">
@@ -149,6 +152,8 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
 
     async function saveMaterial() {
       const formData = new FormData();
+      const token = document.querySelector('#materialForm input[name="csrf_token"]').value;
+      formData.append('csrf_token', token);
       if (materialEditId) formData.append('id', materialEditId);
       formData.append('name', document.getElementById("mat_name").value);
       formData.append('typ', document.getElementById("mat_typ").value);
@@ -163,9 +168,10 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
     }
 
     async function deleteMaterial(id) {
+      const token = document.querySelector('#materialForm input[name="csrf_token"]').value;
       await fetch('delete_material.php', {
         method: 'POST',
-        body: new URLSearchParams({ id })
+        body: new URLSearchParams({ id, csrf_token: token })
       });
       loadData();
     }
@@ -190,6 +196,8 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
 
     async function savePlatte() {
       const formData = new FormData();
+      const token = document.querySelector('#platteForm input[name="csrf_token"]').value;
+      formData.append('csrf_token', token);
       if (plattenEditId) formData.append('id', plattenEditId);
       formData.append('name', document.getElementById("platt_name").value);
       formData.append('typ', document.getElementById("platt_typ").value);
@@ -204,9 +212,10 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
     }
 
     async function deletePlatte(id) {
+      const token = document.querySelector('#platteForm input[name="csrf_token"]').value;
       await fetch('delete_platte.php', {
         method: 'POST',
-        body: new URLSearchParams({ id })
+        body: new URLSearchParams({ id, csrf_token: token })
       });
       loadData();
     }
@@ -239,6 +248,8 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
         return;
       }
       const formData = new FormData();
+      const token = document.querySelector('#fraeserForm input[name="csrf_token"]').value;
+      formData.append('csrf_token', token);
       if (fraeserEditId) formData.append('id', fraeserEditId);
       formData.append('name', document.getElementById("frae_name").value);
       formData.append('typ', document.getElementById("frae_typ").value);
@@ -255,7 +266,11 @@ if (!in_array($_SESSION['rolle'] ?? '', ['admin', 'editor'])) {
     }
 
     async function deleteFraeser(id) {
-      await fetch('delete_fraeser.php?id=' + id);
+      const token = document.querySelector('#fraeserForm input[name="csrf_token"]').value;
+      await fetch('delete_fraeser.php', {
+        method: 'POST',
+        body: new URLSearchParams({ id, csrf_token: token })
+      });
       loadData();
     }
 

--- a/admin_user.php
+++ b/admin_user.php
@@ -14,6 +14,12 @@
   $meldung = "";
   $validRoles = ['admin', 'editor', 'viewer'];
 
+  if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+      if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+          die('Ungültiger CSRF-Token');
+      }
+  }
+
   if (isset($_POST['neuer_benutzer'])) {
       if (in_array($_POST['rolle'], $validRoles, true)) {
           $stmt = $pdo->prepare("INSERT INTO users (username, password_hash, rolle) VALUES (?, ?, ?)");
@@ -85,6 +91,7 @@
   <?php endif; ?>
 
   <form method="post">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <input type="text" name="username" placeholder="Benutzername" required>
     <input type="password" name="password" placeholder="Passwort" required>
     <select name="rolle">
@@ -104,6 +111,7 @@
         <td><?= htmlspecialchars($n['rolle']) ?></td>
         <td>
           <form method="post" style="margin-bottom:5px">
+            <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
             <input type="hidden" name="id" value="<?= htmlspecialchars($n['id']) ?>">
             <input type="password" name="password" placeholder="Neues Passwort (leer = bleibt)">
             <select name="rolle">
@@ -114,6 +122,7 @@
             <button type="submit" name="edit_benutzer">💾 Speichern</button>
           </form>
           <form method="post">
+            <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
             <input type="hidden" name="id" value="<?= htmlspecialchars($n['id']) ?>">
             <button type="submit" name="loeschen" onclick="return confirm('Soll dieser Benutzer wirklich gelöscht werden?')">🗑️ Löschen</button>
           </form>

--- a/csrf.php
+++ b/csrf.php
@@ -1,0 +1,21 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function generate_csrf_token(): string {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function validate_csrf_token(string $token): bool {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    if (empty($_SESSION['csrf_token']) || empty($token)) {
+        return false;
+    }
+    return hash_equals($_SESSION['csrf_token'], $token);
+}

--- a/delete_fraeser.php
+++ b/delete_fraeser.php
@@ -1,18 +1,29 @@
 <?php
 require 'session_check.php';
+require_once 'csrf.php';
 require_once 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
 
 if (defined('DEMO_MODE') && DEMO_MODE) {
   echo "🚫 Löschen im Demo-Modus nicht erlaubt.";
   exit;
 }
 
+if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+  http_response_code(400);
+  echo 'Ungültiger CSRF-Token';
+  exit;
+}
+
 $pdo = getPDO();
 
-$id = $_POST['id'] ?? $_GET['id'] ?? null;
-if ($id) {
+if (isset($_POST['id'])) {
   $stmt = $pdo->prepare("DELETE FROM fraeser WHERE id = ?");
-  $stmt->execute([$id]);
+  $stmt->execute([$_POST['id']]);
   echo "OK";
 }
 ?>

--- a/delete_material.php
+++ b/delete_material.php
@@ -1,5 +1,6 @@
 <?php
 require 'session_check.php';
+require_once 'csrf.php';
 require_once 'db.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -13,6 +14,12 @@ if (defined('DEMO_MODE') && DEMO_MODE) {
 }
 
 $pdo = getPDO();
+
+if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+  http_response_code(400);
+  echo 'Ungültiger CSRF-Token';
+  exit;
+}
 
 if (isset($_POST['id'])) {
   $stmt = $pdo->prepare("DELETE FROM materialien WHERE id = ?");

--- a/delete_platte.php
+++ b/delete_platte.php
@@ -1,5 +1,6 @@
 <?php
 require 'session_check.php';
+require_once 'csrf.php';
 require_once 'db.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -13,6 +14,12 @@ if (defined('DEMO_MODE') && DEMO_MODE) {
 }
 
 $pdo = getPDO();
+
+if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+  http_response_code(400);
+  echo 'Ungültiger CSRF-Token';
+  exit;
+}
 
 if (isset($_POST['id'])) {
   $stmt = $pdo->prepare("DELETE FROM platten WHERE id = ?");

--- a/header.php
+++ b/header.php
@@ -1,5 +1,6 @@
 <?php
   require_once 'require_config.php';
+  require_once 'csrf.php';
   // Für Seiten, die Session-Handling benötigen:
   if (defined('REQUIRE_SESSION')) {
     require 'session_check.php';

--- a/install.php
+++ b/install.php
@@ -8,6 +8,8 @@ if (file_exists('config.php')) {
   }
 }
 
+require_once 'csrf.php';
+
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 ?>
 <!DOCTYPE html>
@@ -24,6 +26,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 <body>
   <h2>🛠️ Web-Installer: Zerspanungsrechner</h2>
   <form method="post">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <label>Datenbank-Host:</label>
     <input name="dbhost" value="localhost" required>
     <label>Datenbank-Benutzer (z. B. root):</label>
@@ -51,11 +54,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
       <option value="false">Nein</option>
       <option value="true">Ja</option>
     </select>
-    <button type="submit">Installation starten</button>
+  <button type="submit">Installation starten</button>
   </form>
 </body>
 </html>
 <?php exit; }
+
+if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+  die('Ungültiger CSRF-Token');
+}
 
 $dbhost = $_POST['dbhost'];
 $dbuser = $_POST['dbuser'];

--- a/login.php
+++ b/login.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'db.php';
 session_start();
+require_once 'csrf.php';
 
 // Bereits eingeloggt? Dann weiter zur Zerspanung (HTML-Datei)
 if (isset($_SESSION['username'])) {
@@ -12,6 +13,9 @@ $error = '';
 $username = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+        die('Ungültiger CSRF-Token');
+    }
     $username = trim($_POST['username'] ?? '');
     $password = trim($_POST['password'] ?? '');
 
@@ -128,6 +132,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <p class="error"><?= htmlspecialchars($error) ?></p>
     <?php endif ?>
     <form method="post" action="login.php">
+      <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
       <label for="username">Benutzername</label>
       <input type="text" id="username" name="username" value="<?= htmlspecialchars($username) ?>" required>
 

--- a/pdf_preview.php
+++ b/pdf_preview.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'vendor/autoload.php';
+require_once 'csrf.php';
 
 function extract_data($text) {
   $data = [
@@ -25,6 +26,9 @@ $extracted = null;
 $save_success = false;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+    die('Ungültiger CSRF-Token');
+  }
   if (isset($_POST['save'])) {
     if (!empty($_POST['werkstoff'])) {
       require_once 'db.php';
@@ -99,6 +103,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
   <h2>🔍 PDF-Wertvorschau</h2>
   <form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <label>PDF-Datei hochladen:</label>
     <input type="file" name="pdf" accept="application/pdf" required>
     <button type="submit">📤 Hochladen & Auslesen</button>
@@ -112,6 +117,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <?php if ($extracted): ?>
   <h3>📋 Vorschau erkannter Werte:</h3>
   <form method="post">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <label>Werkstoff:</label>
     <input name="werkstoff" value="<?= htmlspecialchars($extracted['werkstoff']) ?>">
     <label>Schnittgeschwindigkeit (vc):</label>

--- a/profil.php
+++ b/profil.php
@@ -12,6 +12,9 @@ $pdo = getPDO();
 
 $meldung = "";
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+    die('Ungültiger CSRF-Token');
+  }
   $neuesPasswort = $_POST['password'];
   if (!empty($neuesPasswort)) {
     $hash = password_hash($neuesPasswort, PASSWORD_DEFAULT);
@@ -32,6 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <h2>👤 Mein Profil</h2>
   <p>Angemeldet als: <strong><?= htmlspecialchars($currentUser) ?></strong> (<?= $_SESSION['rolle'] ?>)</p>
   <form method="post">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <label>Neues Passwort:</label>
     <input type="password" name="password" required>
     <button type="submit">🔒 Passwort ändern</button>

--- a/register.php
+++ b/register.php
@@ -1,11 +1,14 @@
 <?php
   // define('REQUIRE_SESSION', true);
   $pageTitle = 'Registrieren';
-  include 'header.php';
+include 'header.php';
 require_once 'db.php';
 $meldung = "";
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+    die('Ungültiger CSRF-Token');
+  }
   $pdo = getPDO();
 
   $username = $_POST['username'];
@@ -32,6 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   </style>
   <h2>📝 Registrieren</h2>
   <form method="post">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <input type="text" name="username" placeholder="Benutzername" required>
     <input type="password" name="password" placeholder="Passwort" required>
     <button type="submit">Konto erstellen</button>

--- a/save_fraeser.php
+++ b/save_fraeser.php
@@ -1,8 +1,15 @@
 <?php
 require 'session_check.php';
+require_once 'csrf.php';
 require_once 'db.php';
 
 $pdo = getPDO();
+
+if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+  http_response_code(400);
+  echo 'Ungültiger CSRF-Token';
+  exit;
+}
 
 if (isset($_POST['loeschen'])) {
   if (defined('DEMO_MODE') && DEMO_MODE) {

--- a/save_material.php
+++ b/save_material.php
@@ -1,8 +1,15 @@
 <?php
 require 'session_check.php';
+require_once 'csrf.php';
 require_once 'db.php';
 
 $pdo = getPDO();
+
+if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+  http_response_code(400);
+  echo 'Ungültiger CSRF-Token';
+  exit;
+}
 
 if (isset($_POST['loeschen'])) {
   if (defined('DEMO_MODE') && DEMO_MODE) {

--- a/save_platte.php
+++ b/save_platte.php
@@ -1,8 +1,15 @@
 <?php
 require 'session_check.php';
+require_once 'csrf.php';
 require_once 'db.php';
 
 $pdo = getPDO();
+
+if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+  http_response_code(400);
+  echo 'Ungültiger CSRF-Token';
+  exit;
+}
 
 if (isset($_POST['loeschen'])) {
   if (defined('DEMO_MODE') && DEMO_MODE) {

--- a/settings.php
+++ b/settings.php
@@ -14,6 +14,9 @@ if (LOGIN_REQUIRED) {
 
 $meldung = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+        die('Ungültiger CSRF-Token');
+    }
     $aktiv = isset($_POST['login_required']);
     $config = file_get_contents('config.php');
     if ($config !== false) {
@@ -42,6 +45,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <p class="info"><?= htmlspecialchars($meldung) ?></p>
 <?php endif; ?>
 <form method="post">
+  <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
   <label><input type="checkbox" name="login_required" <?= LOGIN_REQUIRED ? 'checked' : '' ?>> Login/Benutzerverwaltung aktiv</label>
   <button type="submit">Speichern</button>
 </form>

--- a/update.php
+++ b/update.php
@@ -16,10 +16,14 @@
   <h2>🔄 Update-System</h2>
   <p>Dieses Skript führt Datenbankaktualisierungen für bestehende Installationen aus.</p>
   <form method="post">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <button name="update" value="1">⚙️ Update ausführen</button>
   </form>
 <?php
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
+  if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+    die('Ungültiger CSRF-Token');
+  }
   $pdo = getPDO();
   $res = $pdo->query("SHOW COLUMNS FROM fraeser LIKE 'durchmesser'");
   if ($res->rowCount() === 0) {

--- a/upload_pdf.php
+++ b/upload_pdf.php
@@ -2,7 +2,11 @@
   define('REQUIRE_SESSION', true);
   $pageTitle = 'PDF-Upload';
   include 'header.php';
-  if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['pdf'])) {
+  if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!validate_csrf_token($_POST['csrf_token'] ?? '')) {
+    die('Ungültiger CSRF-Token');
+  }
+  if (isset($_FILES['pdf'])) {
   $file = $_FILES['pdf']['tmp_name'];
   $dest = __DIR__ . '/uploads/' . basename($_FILES['pdf']['name']);
   if (!file_exists(__DIR__ . '/uploads')) {
@@ -25,6 +29,7 @@
   } else {
     echo "<p style='color:red'>❌ Fehler beim Hochladen der Datei.</p>";
   }
+  }
 }
 ?>
 <style>
@@ -36,6 +41,7 @@
 
   <h2>📤 PDF-Upload & Textanalyse</h2>
   <form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="<?= generate_csrf_token(); ?>">
     <label>Wähle PDF-Datei aus:</label>
     <input type="file" name="pdf" accept="application/pdf" required>
     <button type="submit">⬆️ Hochladen & Auslesen</button>


### PR DESCRIPTION
## Summary
- Introduce reusable CSRF helper with token generation and validation
- Embed CSRF tokens in all forms and AJAX requests
- Enforce token validation on all POST handlers and admin APIs

## Testing
- `php -l admin.php`
- `php -l admin_user.php`
- `php -l delete_fraeser.php`
- `php -l delete_material.php`
- `php -l delete_platte.php`
- `php -l header.php`
- `php -l install.php`
- `php -l login.php`
- `php -l pdf_preview.php`
- `php -l profil.php`
- `php -l register.php`
- `php -l save_fraeser.php`
- `php -l save_material.php`
- `php -l save_platte.php`
- `php -l settings.php`
- `php -l update.php`
- `php -l upload_pdf.php`
- `php -l csrf.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8c06fa1dc8327b822dce35ca3ad74