### PR TITLE
chore: track composer lock and document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 config.php
 vendor/
-composer.lock

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ composer install
 sudo apt install composer
 ```
 Anschließend im Projektordner `composer install` ausführen. Die installierten
-Abhängigkeiten landen im Ordner `vendor/`. Dieser Ordner und die Datei
-`composer.lock` sind in der Versionskontrolle ignoriert.
+Abhängigkeiten landen im Ordner `vendor/`. Der `vendor/`-Ordner bleibt in der Versionskontrolle ignoriert,
+`composer.lock` wird hingegen mit versioniert, um reproduzierbare Installationen sicherzustellen.
+Für Bibliotheken kann die Lock-Datei entfallen, für Anwendungen wie diese sollte sie jedoch versioniert werden.
 
 ## 📂 Dateien & Seiten
 


### PR DESCRIPTION
## Summary
- stop ignoring composer.lock so dependency lock is tracked
- clarify in README that composer.lock should be committed for apps

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a8c3f491288327b30f91915cc41439