### PR TITLE
Validate material input parameters before database operations

### DIFF
--- a/save_material.php
+++ b/save_material.php
@@ -16,34 +16,94 @@ if (isset($_POST['loeschen'])) {
     echo "🚫 Löschen im Demo-Modus nicht erlaubt.";
     exit;
   }
+  $id = $_POST['id'] ?? null;
+  if ($id === null || !ctype_digit((string)$id)) {
+    http_response_code(400);
+    echo 'Ungültige ID';
+    exit;
+  }
   $stmt = $pdo->prepare("DELETE FROM materialien WHERE id = ?");
-  $stmt->execute([$_POST['id']]);
+  $stmt->execute([(int)$id]);
+  exit;
+}
+
+// Eingaben validieren
+$name = trim($_POST['name'] ?? '');
+if ($name === '') {
+  http_response_code(400);
+  echo 'Ungültiger Name';
+  exit;
+}
+
+$typ = trim($_POST['typ'] ?? '');
+if ($typ === '') {
+  http_response_code(400);
+  echo 'Ungültiger Typ';
+  exit;
+}
+
+$gruppe = $_POST['gruppe'] ?? '';
+$allowedGruppen = ['P', 'M', 'K', 'N', 'S', 'H'];
+if (!in_array($gruppe, $allowedGruppen, true)) {
+  http_response_code(400);
+  echo 'Ungültige Gruppe';
+  exit;
+}
+
+$vc_hss = $_POST['vc_hss'] ?? null;
+if ($vc_hss === null || !is_numeric($vc_hss) || $vc_hss <= 0) {
+  http_response_code(400);
+  echo 'Ungültiges vc HSS';
+  exit;
+}
+$vc_hss = floatval($vc_hss);
+
+$vc_hartmetall = $_POST['vc_hartmetall'] ?? null;
+if ($vc_hartmetall === null || !is_numeric($vc_hartmetall) || $vc_hartmetall <= 0) {
+  http_response_code(400);
+  echo 'Ungültiges vc Hartmetall';
+  exit;
+}
+$vc_hartmetall = floatval($vc_hartmetall);
+
+$kc = $_POST['kc'] ?? null;
+if ($kc === null || !is_numeric($kc) || $kc <= 0) {
+  http_response_code(400);
+  echo 'Ungültiger kc';
+  exit;
+}
+$kc = floatval($kc);
+
+$id = $_POST['id'] ?? null;
+if ($id !== null && $id !== '' && !ctype_digit((string)$id)) {
+  http_response_code(400);
+  echo 'Ungültige ID';
   exit;
 }
 
 // INSERT oder UPDATE
-if (!empty($_POST['id'])) {
+if ($id) {
   // UPDATE
   $stmt = $pdo->prepare("UPDATE materialien SET name=?, typ=?, gruppe=?, vc_hss=?, vc_hartmetall=?, kc=? WHERE id=?");
   $stmt->execute([
-    $_POST['name'],
-    $_POST['typ'],
-    $_POST['gruppe'],
-    $_POST['vc_hss'],
-    $_POST['vc_hartmetall'],
-    $_POST['kc'],
-    $_POST['id']
+    $name,
+    $typ,
+    $gruppe,
+    $vc_hss,
+    $vc_hartmetall,
+    $kc,
+    (int)$id
   ]);
 } else {
   // INSERT
   $stmt = $pdo->prepare("INSERT INTO materialien (name, typ, gruppe, vc_hss, vc_hartmetall, kc) VALUES (?, ?, ?, ?, ?, ?)");
   $stmt->execute([
-    $_POST['name'],
-    $_POST['typ'],
-    $_POST['gruppe'],
-    $_POST['vc_hss'],
-    $_POST['vc_hartmetall'],
-    $_POST['kc']
+    $name,
+    $typ,
+    $gruppe,
+    $vc_hss,
+    $vc_hartmetall,
+    $kc
   ]);
 }
 echo "OK";


### PR DESCRIPTION
## Summary
- add server-side validation for material name, type, group and machining parameters
- cast numeric values before executing queries and return clear errors for invalid input

## Testing
- `php -l save_material.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8c94a269083278e5d704bc8a321ad